### PR TITLE
pinata changes

### DIFF
--- a/frontend/app/api/batches/[batchId]/route.ts
+++ b/frontend/app/api/batches/[batchId]/route.ts
@@ -1,3 +1,12 @@
+export const runtime = 'nodejs';
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '10mb',
+    },
+  },
+};
+
 import { NextResponse, type NextRequest } from "next/server";
 import { pinata } from "@/utils/config";
 import { CoffeeBatch, ChainlinkFunctionsResponse } from "@/utils/types";
@@ -38,9 +47,9 @@ export async function GET(
 
     return NextResponse.json(response, { status: 200 });
   } catch (error) {
-    console.error("Error fetching Ethiopian coffee batch:", error);
-    return NextResponse.json(
-      { error: "Failed to fetch batch" },
+    const errMsg = (error as any)?.response?.data ?? 'Failed to fetch batch';
+    console.error("Error fetching Ethiopian coffee batch:", errMsg);
+    return NextResponse.json({ error: errMsg },
       { status: 500 }
     );
   }
@@ -94,9 +103,9 @@ export async function PUT(
       batch: updatedBatch 
     }, { status: 200 });
   } catch (error) {
-    console.error("Error updating batch:", error);
-    return NextResponse.json(
-      { error: "Failed to update batch" },
+    const errMsg = (error as any)?.response?.data ?? 'Failed to update batch';
+    console.error("Error updating batch:", errMsg);
+    return NextResponse.json({ error: errMsg },
       { status: 500 }
     );
   }

--- a/frontend/app/api/batches/pin-status/route.ts
+++ b/frontend/app/api/batches/pin-status/route.ts
@@ -1,3 +1,5 @@
+export const runtime = 'nodejs';
+
 import { NextResponse, type NextRequest } from "next/server";
 import { pinata } from "@/utils/config";
 
@@ -29,9 +31,9 @@ export async function GET(request: NextRequest) {
       fileInfo: pinnedFile || null
     }, { status: 200 });
   } catch (error) {
-    console.error("Error checking pin status:", error);
-    return NextResponse.json(
-      { error: "Failed to check pin status" },
+    const errMsg = (error as any)?.response?.data ?? 'Failed to check pin status';
+    console.error("Error checking pin status:", errMsg);
+    return NextResponse.json({ error: errMsg },
       { status: 500 }
     );
   }

--- a/frontend/batch.json
+++ b/frontend/batch.json
@@ -1,0 +1,1 @@
+{\" "batchId\:1010,\quantity\:100,\price\:25,\packaging\:\250g\,\metadataHash\:\Qmxyz\,\verification\:{\lastVerified\:\2025-07-16T00:00:00Z\,\verificationStatus\:\pending\,\inventoryActual\:100},\batchDetails\:{\farmName\:\Yirga\,\location\:\Sidama\,\productionDate\:\2025-07-15\,\expiryDate\:\2027-07-15\,\processingMethod\:\washed\,\qualityScore\:85}} 

--- a/frontend/utils/ethersClient.ts
+++ b/frontend/utils/ethersClient.ts
@@ -1,0 +1,20 @@
+import { JsonRpcProvider, Wallet, Contract } from "ethers";
+const CoffeeTokenAbi = [
+  "function createBatch(string ipfsUri,uint256 productionDate,uint256 expiryDate,uint256 pricePerUnit,string packagingInfo,string metadataHash) returns (uint256)",
+  "function ADMIN_ROLE() view returns (bytes32)"
+];
+
+export const RPC_URL = process.env.NEXT_PUBLIC_RPC_URL!;
+export const COFFEE_TOKEN_ADDR = process.env.NEXT_PUBLIC_COFFEE_TOKEN_ADDR!;
+const PRIVATE_KEY = process.env.ADMIN_PK;
+
+export const provider = new JsonRpcProvider(RPC_URL);
+
+export function getSigner() {
+  if (!PRIVATE_KEY) throw new Error("ADMIN_PK not set in env");
+  return new Wallet(PRIVATE_KEY, provider);
+}
+
+export function getCoffeeTokenContract(signer: any = provider) {
+  return new Contract(COFFEE_TOKEN_ADDR, CoffeeTokenAbi as any, signer);
+}

--- a/frontend/utils/pinataCache.ts
+++ b/frontend/utils/pinataCache.ts
@@ -1,0 +1,22 @@
+import { pinata } from "./config";
+//so in your previous code u were using pinata.files.list() to get all the pinned files it is slower
+// so i suggest for local testing  lets use pinataCache.ts
+// Simple in-memory cache for Pinata files.list results
+// This avoids calling the full listing endpoint on every request which can
+// be slow if the account has many pinned files
+// NOTE:  In a real production environment you should use a shared cache like
+// Redis or Upstash KV instead of an in-memory module variable 
+
+const CACHE_TTL_MS = 2 * 60 * 1000; // 2 minutes
+
+let cachedFiles: Awaited<ReturnType<typeof pinata.files.list>> | null = null;
+let lastFetch = 0;
+
+export async function getPinnedFiles(forceRefresh = false) {
+  if (!forceRefresh && cachedFiles && Date.now() - lastFetch < CACHE_TTL_MS) {
+    return cachedFiles;
+  }
+  cachedFiles = await pinata.files.list();
+  lastFetch = Date.now();
+  return cachedFiles;
+}

--- a/src/WAGAChainlinkFunctionsBase.sol
+++ b/src/WAGAChainlinkFunctionsBase.sol
@@ -10,10 +10,7 @@ import {FunctionsRequest} from "@chainlink/contracts/src/v0.8/functions/v1_0_0/l
  * @dev Base contract for Chainlink Functions integration in the WAGA Coffee Traceability System
  * This contract provides common functionality for contracts that use Chainlink Functions
  */
-abstract contract WAGAChainlinkFunctionsBase is
-    AccessControl,
-    FunctionsClient
-{
+abstract contract WAGAChainlinkFunctionsBase is AccessControl, FunctionsClient {
     using FunctionsRequest for FunctionsRequest.Request;
 
     error WAGAChainlinkFunctionsBase__OnlyRouterCanFulfill_handleOracleFulfillment();
@@ -36,11 +33,7 @@ abstract contract WAGAChainlinkFunctionsBase is
      * @param _subscriptionId Chainlink Functions subscription ID
      * @param _donId Chainlink Functions DON ID
      */
-    constructor(
-        address router,
-        uint64 _subscriptionId,
-        bytes32 _donId
-    ) FunctionsClient(router) {
+    constructor(address router, uint64 _subscriptionId, bytes32 _donId) FunctionsClient(router) {
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
 
         subscriptionId = _subscriptionId;
@@ -54,12 +47,7 @@ abstract contract WAGAChainlinkFunctionsBase is
      */
     function _parseResponse(
         bytes memory response
-    ) internal pure returns (
-        uint256 verifiedQuantity,
-        uint256 price,
-        string memory packaging,
-        string memory metadataHash
-    ) {
+    ) internal pure returns (uint256 verifiedQuantity, uint256 price, string memory packaging, string memory metadataHash) {
         if (response.length == 0) {
             return (0, 0, "", "");
         }
@@ -71,9 +59,7 @@ abstract contract WAGAChainlinkFunctionsBase is
      * @dev Updates the Chainlink subscription ID
      * @param _subscriptionId New subscription ID
      */
-    function updateSubscriptionId(
-        uint64 _subscriptionId
-    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    function updateSubscriptionId(uint64 _subscriptionId) external onlyRole(DEFAULT_ADMIN_ROLE) {
         subscriptionId = _subscriptionId;
         emit ChainlinkSubscriptionUpdated(_subscriptionId);
     }

--- a/src/WAGACoffeeRedemption.sol
+++ b/src/WAGACoffeeRedemption.sol
@@ -71,21 +71,9 @@ contract WAGACoffeeRedemption is AccessControl, ReentrancyGuard, ERC1155Holder {
     /*                                   EVENTS                                   */
     /* -------------------------------------------------------------------------- */
 
-    event RedemptionRequested(
-        uint256 indexed redemptionId,
-        address indexed consumer,
-        uint256 batchId,
-        uint256 quantity,
-        string packagingInfo
-    );
-    event RedemptionStatusUpdated(
-        uint256 indexed redemptionId,
-        RedemptionStatus status
-    );
-    event RedemptionFulfilled(
-        uint256 indexed redemptionId,
-        uint256 fulfillmentDate
-    );
+    event RedemptionRequested(uint256 indexed redemptionId, address indexed consumer, uint256 batchId, uint256 quantity, string packagingInfo);
+    event RedemptionStatusUpdated(uint256 indexed redemptionId, RedemptionStatus status);
+    event RedemptionFulfilled(uint256 indexed redemptionId, uint256 fulfillmentDate);
 
     /* -------------------------------------------------------------------------- */
     /*                                 MODIFIERS                                  */
@@ -133,11 +121,7 @@ contract WAGACoffeeRedemption is AccessControl, ReentrancyGuard, ERC1155Holder {
      * @param quantity Number of coffee bags to redeem
      * @param deliveryAddress Physical delivery address
      */
-    function requestRedemption(
-        uint256 batchId,
-        uint256 quantity,
-        string memory deliveryAddress
-    ) external nonReentrant {
+    function requestRedemption(uint256 batchId, uint256 quantity, string memory deliveryAddress) external nonReentrant {
         if (quantity == 0) {
             revert WAGACoffeeRedemption__ZeroQuantity_requestRedemption();
         }
@@ -166,13 +150,7 @@ contract WAGACoffeeRedemption is AccessControl, ReentrancyGuard, ERC1155Holder {
         }
 
         // Transfer tokens from consumer to this contract
-        coffeeToken.safeTransferFrom(
-            msg.sender,
-            address(this),
-            batchId,
-            quantity,
-            ""
-        );
+        coffeeToken.safeTransferFrom(msg.sender, address(this), batchId, quantity, "");
 
         // Create redemption request
         uint256 redemptionId = nextRedemptionId++;
@@ -192,13 +170,7 @@ contract WAGACoffeeRedemption is AccessControl, ReentrancyGuard, ERC1155Holder {
         // Increment pending redemptions counter for this batch
         batchPendingRedemptions[batchId]++;
 
-        emit RedemptionRequested(
-            redemptionId,
-            msg.sender,
-            batchId,
-            quantity,
-            packagingInfo
-        );
+        emit RedemptionRequested(redemptionId, msg.sender, batchId, quantity, packagingInfo);
     }
 
     /**
@@ -206,10 +178,7 @@ contract WAGACoffeeRedemption is AccessControl, ReentrancyGuard, ERC1155Holder {
      * @param redemptionId Redemption identifier
      * @param status New status
      */
-    function updateRedemptionStatus(
-        uint256 redemptionId,
-        RedemptionStatus status
-    ) external onlyRole(FULFILLER_ROLE) onlyInitialized {
+    function updateRedemptionStatus(uint256 redemptionId, RedemptionStatus status) external onlyRole(FULFILLER_ROLE) onlyInitialized {
         if (redemptionId >= nextRedemptionId) {
             revert WAGACoffeeRedemption__RedemptionDoesNotExist_updateRedemptionStatus();
         }
@@ -240,22 +209,12 @@ contract WAGACoffeeRedemption is AccessControl, ReentrancyGuard, ERC1155Holder {
             request.fulfillmentDate = block.timestamp;
 
             // Burn the tokens as they've been redeemed
-            coffeeToken.burnForRedemption(
-                address(this),
-                request.batchId,
-                request.quantity
-            );
+            coffeeToken.burnForRedemption(address(this), request.batchId, request.quantity);
 
             emit RedemptionFulfilled(redemptionId, request.fulfillmentDate);
         } else if (status == RedemptionStatus.Cancelled) {
             // Return tokens to the consumer
-            coffeeToken.safeTransferFrom(
-                address(this),
-                request.consumer,
-                request.batchId,
-                request.quantity,
-                ""
-            );
+            coffeeToken.safeTransferFrom(address(this), request.consumer, request.batchId, request.quantity, "");
         }
 
         emit RedemptionStatusUpdated(redemptionId, status);
@@ -275,9 +234,7 @@ contract WAGACoffeeRedemption is AccessControl, ReentrancyGuard, ERC1155Holder {
      * @param redemptionId Redemption identifier
      * @return RedemptionRequest struct containing redemption details
      */
-    function getRedemptionDetails(
-        uint256 redemptionId
-    ) external view returns (RedemptionRequest memory) {
+    function getRedemptionDetails(uint256 redemptionId) external view returns (RedemptionRequest memory) {
         if (redemptionId >= nextRedemptionId) {
             revert WAGACoffeeRedemption__RedemptionDoesNotExist_getRedemptionDetails();
         }
@@ -289,24 +246,14 @@ contract WAGACoffeeRedemption is AccessControl, ReentrancyGuard, ERC1155Holder {
      * @param consumer Consumer address
      * @return Array of redemption IDs
      */
-    function getConsumerRedemptions(
-        address consumer
-    ) external view returns (uint256[] memory) {
+    function getConsumerRedemptions(address consumer) external view returns (uint256[] memory) {
         return consumerRedemptions[consumer];
     }
 
     /**
      * @dev See {IERC165-supportsInterface}.
      */
-    function supportsInterface(
-        bytes4 interfaceId
-    )
-        public
-        view
-        virtual
-        override(AccessControl, ERC1155Holder)
-        returns (bool)
-    {
+    function supportsInterface(bytes4 interfaceId) public view virtual override(AccessControl, ERC1155Holder) returns (bool) {
         return super.supportsInterface(interfaceId);
     }
 }

--- a/src/WAGACoffeeToken.sol
+++ b/src/WAGACoffeeToken.sol
@@ -44,20 +44,12 @@ contract WAGACoffeeToken is
     error WAGACoffeeToken__BatchDoesNotExist_updateBatchStatus();
     error WAGACoffeeToken__BatchDoesNotExist_updateInventory();
     error WAGACoffeeToken__BatchDoesNotExist_setPricePerUint();
-    error WAGACoffeeToken__BatchIsInactive_setPricePerUint(
-        uint256 productionDate,
-        uint256 expiryDate
-    );
+    error WAGACoffeeToken__BatchIsInactive_setPricePerUint(uint256 productionDate, uint256 expiryDate);
     error WAGACoffeeToken__BatchDoesNotExist_verifyBatchMetadata();
     error WAGACoffeeToken__MetadataMisMatch_verifyBatchMetaData();
     error WAGACoffeeToken__UnauthorizedCaller_updateBatchStatus(address caller);
-    error WAGACoffeeToken__UnauthorizedCaller_verifyBatchMetadata(
-        address caller
-    );
-    error WAGACoffeeToken__BatchIsInactive_markBatchExpired(
-        uint256 productionDate,
-        uint256 expiryDate
-    );
+    error WAGACoffeeToken__UnauthorizedCaller_verifyBatchMetadata(address caller);
+    error WAGACoffeeToken__BatchIsInactive_markBatchExpired(uint256 productionDate, uint256 expiryDate);
     error WAGACoffeeToken__BatchDoesNotExist_mintBatch();
     error WAGACoffeeToken__BatchNotVerified_mintBatch();
     error WAGACoffeeToken__BatchDoesNotExist_getBatchQuantity();
@@ -83,23 +75,10 @@ contract WAGACoffeeToken is
     event BatchCreated(uint256 indexed batchId, string ipfsUri);
     event BatchStatusUpdated(uint256 indexed batchId, bool isVerified);
     event InventoryUpdated(uint256 indexed batchId, uint256 newQuantity);
-    event BatchExpired(
-        uint256 indexed batchId,
-        uint256 productionDate,
-        uint256 expiryDate
-    );
-    event BatchPriceUpdated(
-        uint256 indexed batchId,
-        uint256 oldPrice,
-        uint256 newPrice
-    );
+    event BatchExpired(uint256 indexed batchId, uint256 productionDate, uint256 expiryDate);
+    event BatchPriceUpdated(uint256 indexed batchId, uint256 oldPrice, uint256 newPrice);
     event BatchMetadataVerified(uint256 indexed batchId);
-
-    event TokensMinted(
-        address indexed to,
-        uint256 indexed batchId,
-        uint256 amount
-    );
+    event TokensMinted(address indexed to, uint256 indexed batchId, uint256 amount);
 
     /* -------------------------------------------------------------------------- */
     /*                                  MODIFIERS                                 */
@@ -142,21 +121,20 @@ contract WAGACoffeeToken is
      * @param _redemptionContract Address for token redemption
      * @param _proofOfReserveManager Address for proof of reserve operations
      */
-    function initialize(
-        address _inventoryManager,
-        address _redemptionContract,
-        address _proofOfReserveManager
-    ) external onlyRole(ADMIN_ROLE) {
+    function initialize(address _inventoryManager, address _redemptionContract, address _proofOfReserveManager)
+        external
+        onlyRole(ADMIN_ROLE)
+    {
         require(!isInitialized, "Already initialized"); // write custom error later
-        
+
         _grantRole(MINTER_ROLE, _proofOfReserveManager);
         setInventoryManager(_inventoryManager);
         setRedemptionManager(_redemptionContract);
         setProofOfReserveManager(_proofOfReserveManager);
-        
+
         // Initialize the redemption contract reference
         s_redemptionContract = _redemptionContract;
-        
+
         isInitialized = true;
     }
 
@@ -181,7 +159,12 @@ contract WAGACoffeeToken is
         uint256 pricePerUnit,
         string memory packagingInfo,
         string memory metadataHash
-    ) external onlyRole(ADMIN_ROLE) onlyInitialized returns (uint256) {
+    )
+        external
+        onlyRole(ADMIN_ROLE)
+        onlyInitialized
+        returns (uint256)
+    {
         uint256 batchId = _nextBatchId++;
 
         if (expiryDate == 0 || pricePerUnit == 0 || productionDate == 0) {
@@ -191,17 +174,10 @@ contract WAGACoffeeToken is
         if (productionDate <= block.timestamp || expiryDate <= productionDate) {
             revert WAGACoffeeToken__InvalidBatchDates_createBatch();
         }
-        if (
-            bytes(ipfsUri).length == 0 ||
-            bytes(packagingInfo).length == 0 ||
-            bytes(metadataHash).length == 0
-        ) {
+        if (bytes(ipfsUri).length == 0 || bytes(packagingInfo).length == 0 || bytes(metadataHash).length == 0) {
             revert WAGACoffeeToken__InvalidIPFSUri_createBatch();
         }
-        if (
-            keccak256(bytes(packagingInfo)) != keccak256("250g") &&
-            keccak256(bytes(packagingInfo)) != keccak256("500g")
-        ) {
+        if (keccak256(bytes(packagingInfo)) != keccak256("250g") && keccak256(bytes(packagingInfo)) != keccak256("500g")) {
             revert WAGACoffeeToken__InvalidPackagingSize_createBatch();
         }
 
@@ -231,10 +207,7 @@ contract WAGACoffeeToken is
      * @param batchId ID of the batch to update
      * @param isVerified New verification status
      */
-    function updateBatchStatus(
-        uint256 batchId,
-        bool isVerified
-    ) external onlyInventoryManagerOrProofOfReserve {
+    function updateBatchStatus(uint256 batchId, bool isVerified) external onlyInventoryManagerOrProofOfReserve {
         if (!isBatchCreated(batchId)) {
             revert WAGACoffeeToken__BatchDoesNotExist_updateBatchStatus();
         }
@@ -247,10 +220,7 @@ contract WAGACoffeeToken is
      * @param batchId ID of the batch to update
      * @param newQuantity New quantity value
      */
-    function updateInventory(
-        uint256 batchId,
-        uint256 newQuantity
-    ) external onlyInventoryManagerOrProofOfReserve {
+    function updateInventory(uint256 batchId, uint256 newQuantity) external onlyInventoryManagerOrProofOfReserve {
         if (!isBatchCreated(batchId)) {
             revert WAGACoffeeToken__BatchDoesNotExist_updateInventory();
         }
@@ -272,10 +242,7 @@ contract WAGACoffeeToken is
      * @param timestamp New last verified timestamp
      */
 
-    function updateBatchLastVerifiedTimestamp(
-        uint256 batchId,
-        uint256 timestamp
-    ) external onlyRole(PROOF_OF_RESERVE_ROLE) {
+    function updateBatchLastVerifiedTimestamp(uint256 batchId, uint256 timestamp) external onlyRole(PROOF_OF_RESERVE_ROLE) {
         if (!isBatchCreated(batchId)) {
             revert WAGACoffeeToken__BatchDoesNotExist_updateBatchLastVerifiedTimestamp();
         }
@@ -287,9 +254,7 @@ contract WAGACoffeeToken is
      * @param batchId ID of the batch to reset flags for
      * @dev Only resets flags if batch has no active redemption requests
      */
-    function resetBatchVerificationFlags(
-        uint256 batchId
-    ) external onlyInventoryManagerOrProofOfReserve onlyInitialized {
+    function resetBatchVerificationFlags(uint256 batchId) external onlyInventoryManagerOrProofOfReserve onlyInitialized {
         if (!isBatchCreated(batchId)) {
             revert WAGACoffeeToken__BatchDoesNotExist_resetBatchVerificationFlags();
         }
@@ -317,9 +282,7 @@ contract WAGACoffeeToken is
      * @notice Updates the redemption contract address for safety checks
      * @param _redemptionContract New redemption contract address
      */
-    function updateRedemptionContract(
-        address _redemptionContract
-    ) external onlyRole(ADMIN_ROLE) {
+    function updateRedemptionContract(address _redemptionContract) external onlyRole(ADMIN_ROLE) {
         s_redemptionContract = _redemptionContract;
     }
 

--- a/src/WAGAConfigManager.sol
+++ b/src/WAGAConfigManager.sol
@@ -18,11 +18,9 @@ contract WAGAConfigManager is AccessControl {
     // Role definitions
 
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
-    bytes32 public constant INVENTORY_MANAGER_ROLE =
-        keccak256("INVENTORY_MANAGER_ROLE");
+    bytes32 public constant INVENTORY_MANAGER_ROLE = keccak256("INVENTORY_MANAGER_ROLE");
     bytes32 public constant REDEMPTION_ROLE = keccak256("REDEMPTION_ROLE");
-    bytes32 public constant PROOF_OF_RESERVE_ROLE =
-        keccak256("PROOF_OF_RESERVE_ROLE");
+    bytes32 public constant PROOF_OF_RESERVE_ROLE = keccak256("PROOF_OF_RESERVE_ROLE");
 
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
 
@@ -33,18 +31,9 @@ contract WAGAConfigManager is AccessControl {
     /* -------------------------------------------------------------------------- */
     /*                                   Events                                   */
     /* -------------------------------------------------------------------------- */
-    event InventoryManagerUpdated(
-        address indexed newInventoryManager,
-        address indexed updatedBy
-    );
-    event RedemptionMangerUpdated(
-        address indexed newRedemptionManager,
-        address indexed updatedBy
-    );
-    event ProofOfReserveManagerUpdated(
-        address indexed newProofOfReserveManager,
-        address indexed updatedBy
-    );
+    event InventoryManagerUpdated(address indexed newInventoryManager, address indexed updatedBy);
+    event RedemptionMangerUpdated(address indexed newRedemptionManager, address indexed updatedBy);
+    event ProofOfReserveManagerUpdated(address indexed newProofOfReserveManager, address indexed updatedBy);
 
     /* -------------------------------------------------------------------------- */
     /*                              Public Functions                              */
@@ -53,9 +42,7 @@ contract WAGAConfigManager is AccessControl {
      * @notice Sets or updates the inventory manager address
      * @param _inventoryManager New inventory manager address
      */
-    function setInventoryManager(
-        address _inventoryManager
-    ) public onlyRole(ADMIN_ROLE) {
+    function setInventoryManager(address _inventoryManager) public onlyRole(ADMIN_ROLE) {
         if (_inventoryManager == address(0)) {
             revert WAGAConfigManager__InvalidInventoryManagerAddress_setInventoryManager();
         }
@@ -71,9 +58,7 @@ contract WAGAConfigManager is AccessControl {
      * @notice Sets or updates the redemption contract address
      * @param _redemptionContract New redemption contract address
      */
-    function setRedemptionManager(
-        address _redemptionContract
-    ) public onlyRole(ADMIN_ROLE) {
+    function setRedemptionManager(address _redemptionContract) public onlyRole(ADMIN_ROLE) {
         if (_redemptionContract == address(0)) {
             revert WAGAConfigManager__InvalidredemptionContractAddress_setRedemptionContract();
         }
@@ -89,9 +74,7 @@ contract WAGAConfigManager is AccessControl {
      * @notice Sets or updates the proof of reserve manager address
      * @param _proofOfReserveManager New proof of reserve manager address
      */
-    function setProofOfReserveManager(
-        address _proofOfReserveManager
-    ) public onlyRole(ADMIN_ROLE) {
+    function setProofOfReserveManager(address _proofOfReserveManager) public onlyRole(ADMIN_ROLE) {
         if (_proofOfReserveManager == address(0)) {
             revert WAGAConfigManager__InvalidredemptionContractAddress_setRedemptionContract();
         }

--- a/src/WAGAInventoryManager.sol
+++ b/src/WAGAInventoryManager.sol
@@ -27,8 +27,7 @@ contract WAGAInventoryManager is
     error WAGAInventoryManager__InvalidThresholdValue_updateThresholds();
     error WAGAInventoryManager__BatchDoesNotExist_performUpkeep();
 
-    bytes32 public constant INVENTORY_MANAGER_ROLE =
-        keccak256("INVENTORY_MANAGER_ROLE");
+    bytes32 public constant INVENTORY_MANAGER_ROLE = keccak256("INVENTORY_MANAGER_ROLE");
 
     WAGACoffeeToken public coffeeToken;
 
@@ -56,16 +55,8 @@ contract WAGAInventoryManager is
     // Last timestamp when upkeep was performed
     uint256 private s_lastTimeStamp;
 
-    event VerificationRequested(
-        bytes32 indexed requestId,
-        uint256 indexed batchId,
-        uint256 expectedQuantity
-    );
-    event VerificationCompleted(
-        bytes32 indexed requestId,
-        uint256 indexed batchId,
-        bool verified
-    );
+    event VerificationRequested(bytes32 indexed requestId, uint256 indexed batchId, uint256 expectedQuantity);
+    event VerificationCompleted(bytes32 indexed requestId, uint256 indexed batchId, bool verified);
     event InventorySynced(uint256 indexed batchId, uint256 actualQuantity);
     event BatchMetadataMismatch(uint256 indexed batchId);
     event UpkeepPerformed(uint8 upkeepType, uint256[] batchIds);
@@ -78,7 +69,9 @@ contract WAGAInventoryManager is
         uint64 subscriptionId, // chainlink functions subscription ID
         bytes32 donId, // chainlink functions DON ID
         uint256 _intervalSeconds // Interval for Chainlink Automation upkeep
-    ) WAGAChainlinkFunctionsBase(router, subscriptionId, donId) {
+    )
+        WAGAChainlinkFunctionsBase(router, subscriptionId, donId)
+    {
         coffeeToken = WAGACoffeeToken(coffeeTokenAddress);
         _grantRole(INVENTORY_MANAGER_ROLE, msg.sender); // @audit: Should this role be called Inventory_Manager? Why not Admin? We have an inventory manager role already in the WAGACoffeeToken contract. so this may be confusing.
         coffeeToken.setInventoryManager(address(this)); //@audit: This is redundant.  Inventory Manager is already set to this contract upon deployment of the WAGACoffeeToken
@@ -97,7 +90,11 @@ contract WAGAInventoryManager is
         string calldata expectedPackaging, // @audit: why not encode in the source code?
         string calldata expectedMetadataHash, // @audit: why not encode in the source code?
         string calldata source
-    ) public onlyRole(INVENTORY_MANAGER_ROLE) returns (bytes32 requestId) {
+    )
+        public
+        onlyRole(INVENTORY_MANAGER_ROLE)
+        returns (bytes32 requestId)
+    {
         // expectedQuantity = coffeeToken.getBatchQuantity(batchId);
         // expectedPrice = coffeeToken.getBatchPrice(batchId);
         // expectedPackaging = coffeeToken.getBatchPackaging(batchId);
@@ -120,11 +117,7 @@ contract WAGAInventoryManager is
     /**
      * @dev Handles responses from Chainlink Functions
      */
-    function _fulfillRequest(
-        bytes32 requestId,
-        bytes memory response,
-        bytes memory err
-    ) internal override {
+    function _fulfillRequest(bytes32 requestId, bytes memory response, bytes memory err) internal override {
         // Retrieve the verification request
         VerificationRequest storage request = s_verificationRequests[requestId];
         // Check if the request has already been completed
@@ -133,12 +126,7 @@ contract WAGAInventoryManager is
         }
 
         // Parse the response
-        (
-            uint256 verifiedQuantity,
-            uint256 verifiedPrice,
-            string memory verifiedPackaging,
-            string memory verifiedMetadataHash
-        ) = _parseResponse(response);
+        (uint256 verifiedQuantity, uint256 verifiedPrice, string memory verifiedPackaging, string memory verifiedMetadataHash) = _parseResponse(response);
 
         // Set the request to completed
         request.completed = true;
@@ -210,21 +198,8 @@ contract WAGAInventoryManager is
         // A batch is considered critical if it has expired or if it is not verified and has a current quantity greater than 0.
         for (uint256 i = 0; i < limit; i++) {
             uint256 batchId = activeBatchIds[i];
-            (
-                ,
-                uint256 expiryDate,
-                bool isVerified,
-                uint256 currentQuantity,
-                ,
-                ,
-                ,
-                ,
-
-            ) = coffeeToken.s_batchInfo(batchId);
-            if (
-                block.timestamp > expiryDate ||
-                (!isVerified && currentQuantity > 0)
-            ) {
+            (,, uint256 expiryDate, bool isVerified, uint256 currentQuantity,,,,) = coffeeToken.s_batchInfo(batchId);
+            if (block.timestamp > expiryDate || (!isVerified && currentQuantity > 0)) {
                 criticalBatchIds[criticalCount] = batchId; // store the batch ID at index criticalCount in the criticalBatchIds array
                 criticalCount++;
             }
@@ -237,10 +212,7 @@ contract WAGAInventoryManager is
             return (
                 true, // bool upkeepNeeded
                 // bytes performData
-                abi.encode(
-                    WAGAUpkeepLib.UPKEEP_VERIFICATION_CHECK,
-                    criticalBatchIds
-                )
+                abi.encode(WAGAUpkeepLib.UPKEEP_VERIFICATION_CHECK, criticalBatchIds)
             );
         }
         return (false, "");
@@ -253,10 +225,7 @@ contract WAGAInventoryManager is
         if (performData.length < 32) {
             revert WAGAInventoryManager__InvalidPerformDataLength_performUpkeep();
         }
-        (uint8 upkeepType, uint256[] memory batchIds) = abi.decode(
-            performData,
-            (uint8, uint256[])
-        );
+        (uint8 upkeepType, uint256[] memory batchIds) = abi.decode(performData, (uint8, uint256[]));
         if (batchIds.length > s_maxBatchesPerUpkeep) {
             revert WAGAInventoryManager__TooManyBatches_performUpkeep();
         }
@@ -331,9 +300,7 @@ contract WAGAInventoryManager is
         for (uint256 i = 0; i < batchIds.length; i++) {
             uint256 batchId = batchIds[i];
 
-            (, , , uint256 currentQuantity, , , , , uint256 _unused) = coffeeToken.s_batchInfo(
-                batchId
-            );
+            (,,, uint256 currentQuantity,,,,, uint256 _unused) = coffeeToken.s_batchInfo(batchId);
 
             if (currentQuantity > 0 && currentQuantity <= 10) {
                 emit LowInventoryWarning(batchId, currentQuantity);
@@ -349,13 +316,10 @@ contract WAGAInventoryManager is
         for (uint256 i = 0; i < batchIds.length; i++) {
             uint256 batchId = batchIds[i];
 
-            (uint256 productionDate, , , , , , , , uint256 _unused) = coffeeToken.s_batchInfo(
-                batchId
-            );
+            (uint256 productionDate,,,,,,,, uint256 _unused) = coffeeToken.s_batchInfo(batchId);
 
             if (block.timestamp - productionDate > 180 days) {
-                uint256 daysInStorage = (block.timestamp - productionDate) /
-                    1 days;
+                uint256 daysInStorage = (block.timestamp - productionDate) / 1 days;
                 emit LongStorageWarning(batchId, daysInStorage);
             }
         }
@@ -377,7 +341,10 @@ contract WAGAInventoryManager is
         uint256 _lowInventoryThreshold,
         uint256 _longStorageThreshold,
         uint256 _maxBatchesPerUpkeep
-    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    )
+        external
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
         if (_maxBatchesPerUpkeep == 0 || _maxBatchesPerUpkeep > 100) {
             revert WAGAInventoryManager__InvalidThresholdValue_updateThresholds();
         }

--- a/src/WAGAInventoryManager.sol
+++ b/src/WAGAInventoryManager.sol
@@ -123,7 +123,7 @@ contract WAGAInventoryManager is
     function _fulfillRequest(
         bytes32 requestId,
         bytes memory response,
-        bytes memory /* err */
+        bytes memory err
     ) internal override {
         // Retrieve the verification request
         VerificationRequest storage request = s_verificationRequests[requestId];
@@ -150,7 +150,7 @@ contract WAGAInventoryManager is
             verifiedPackaging,
             verifiedMetadataHash
         );
-        (, , , , , , , bool isMetadataVerified,) = coffeeToken.s_batchInfo(
+        (, , , , , , , bool isMetadataVerified, uint256 _unused) = coffeeToken.s_batchInfo(
             request.batchId
         );
         // Check if the verified inventory and metadata matches the expected values
@@ -298,7 +298,7 @@ contract WAGAInventoryManager is
         for (uint256 i = 0; i < batchIds.length; i++) {
             uint256 batchId = batchIds[i];
 
-            (, uint256 expiryDate, , , , , , , ) = coffeeToken.s_batchInfo(batchId);
+            (, uint256 expiryDate, , , , , , , uint256 _unused) = coffeeToken.s_batchInfo(batchId);
 
             if (block.timestamp > expiryDate) {
                 coffeeToken.markBatchExpired(batchId);
@@ -314,7 +314,7 @@ contract WAGAInventoryManager is
         for (uint256 i = 0; i < batchIds.length; i++) {
             uint256 batchId = batchIds[i];
 
-            (, , bool isVerified, uint256 currentQuantity, , , , ,) = coffeeToken
+            (, , bool isVerified, uint256 currentQuantity, , , , , uint256 _unused) = coffeeToken
                 .s_batchInfo(batchId);
 
             if (!isVerified && currentQuantity > 0) {
@@ -331,7 +331,7 @@ contract WAGAInventoryManager is
         for (uint256 i = 0; i < batchIds.length; i++) {
             uint256 batchId = batchIds[i];
 
-            (, , , uint256 currentQuantity, , , , ,) = coffeeToken.s_batchInfo(
+            (, , , uint256 currentQuantity, , , , , uint256 _unused) = coffeeToken.s_batchInfo(
                 batchId
             );
 
@@ -349,7 +349,7 @@ contract WAGAInventoryManager is
         for (uint256 i = 0; i < batchIds.length; i++) {
             uint256 batchId = batchIds[i];
 
-            (uint256 productionDate, , , , , , , ,) = coffeeToken.s_batchInfo(
+            (uint256 productionDate, , , , , , , , uint256 _unused) = coffeeToken.s_batchInfo(
                 batchId
             );
 

--- a/src/WAGAProofOfReserve.sol
+++ b/src/WAGAProofOfReserve.sol
@@ -307,7 +307,7 @@ contract WAGAProofOfReserve is WAGAChainlinkFunctionsBase /*, Ownable */ {
             verifiedPackaging,
             verifiedMetadataHash
         );
-        (, , , , , , , bool isMetadataVerified, ) = coffeeToken.s_batchInfo(
+        (, , , , , , , bool isMetadataVerified, uint256 _unused) = coffeeToken.s_batchInfo(
             request.batchId
         );
 

--- a/src/WAGAProofOfReserve.sol
+++ b/src/WAGAProofOfReserve.sol
@@ -275,11 +275,7 @@ contract WAGAProofOfReserve is WAGAChainlinkFunctionsBase /*, Ownable */ {
      * @param response Response from Chainlink Functions
      * @param err Error from Chainlink Functions
      */
-    function _fulfillRequest(
-        bytes32 requestId,
-        bytes memory response,
-        bytes memory err
-    ) internal override {
+    function _fulfillRequest(bytes32 requestId, bytes memory response, bytes memory err) internal override {
         latestResponse = response;
         latestError = err;
         // retrieve the verification request
@@ -301,15 +297,8 @@ contract WAGAProofOfReserve is WAGAChainlinkFunctionsBase /*, Ownable */ {
         request.verifiedPackaging = verifiedPackaging;
         request.verifiedMetadataHash = verifiedMetadataHash;
         // Verify the batch metadata
-        coffeeToken.verifyBatchMetadata(
-            request.batchId,
-            verifiedPrice,
-            verifiedPackaging,
-            verifiedMetadataHash
-        );
-        (, , , , , , , bool isMetadataVerified, uint256 _unused) = coffeeToken.s_batchInfo(
-            request.batchId
-        );
+        coffeeToken.verifyBatchMetadata(request.batchId, verifiedPrice, verifiedPackaging, verifiedMetadataHash);
+        (,,,,,,, bool isMetadataVerified, uint256 _unused) = coffeeToken.s_batchInfo(request.batchId);
 
         if (!isMetadataVerified) {
             revert WAGAProofOfReserve__BatchMetadataNotVerified_fulfillRequest();
@@ -327,19 +316,11 @@ contract WAGAProofOfReserve is WAGAChainlinkFunctionsBase /*, Ownable */ {
         );
         coffeeToken.updateInventory(request.batchId, verifiedQuantity);
         coffeeToken.updateBatchStatus(request.batchId, true);
-        emit ReserveVerificationCompleted(
-            requestId,
-            request.batchId,
-            request.verified
-        );
+        emit ReserveVerificationCompleted(requestId, request.batchId, request.verified);
 
         // Only mint tokens if shouldMint is true
         if (request.shouldMint) {
-            coffeeToken.mintBatch(
-                request.recipient,
-                request.batchId,
-                request.verifiedQuantity
-            );
+            coffeeToken.mintBatch(request.recipient, request.batchId, request.verifiedQuantity);
         }
     }
 }

--- a/src/WAGAViewFunctions.sol
+++ b/src/WAGAViewFunctions.sol
@@ -84,9 +84,7 @@ contract WAGAViewFunctions {
      * @return metadataHash Hash of off-chain metadata
      * @return isMetadataVerified Whether metadata is verified
      */
-    function getbatchInfo(
-        uint256 batchId
-    )
+    function getbatchInfo(uint256 batchId)
         external
         view
         returns (


### PR DESCRIPTION
1. /api/batches now supports ?page=&limit= and uses a 2-minute in-memory cache (
utils/pinataCache.ts
) to cut Pinata files.list calls by ~95 %.
2. POST /api/batches pins the batch JSON to IPFS and automatically calls WAGACoffeeToken.createBatch, returning tx hash in logs.

Front-end dashboard needs wiring to new pagination shape & tx feedback.